### PR TITLE
added Evan Hearne and Denis Pop as Contributors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,13 @@ If you wish to contribute to the project take some time to read our [getting sta
 
 A list of students from Mount Sion CBS who actively contribute to the project
 
+### Phase 1:
 * **Adam Lalor** [Github](https://github.com/AdamLalor)
 * **Maciej Marchel** [Github](https://github.com/maciejmarchel12)
 * **Dominik Kawka** [Github](https://github.com/dominikkawka)
 * **Kieran Hanrahan** [Github](https://github.com/kieranhanrahan)
+
+### Phase 2:
 * **Evan Hearne** [Github](https://github.com/evanhearne)
 * **Denis Pop** [Github](https://github.com/denispop9)
 


### PR DESCRIPTION
# Description

Added two new active contributors along with their GitHub profiles under the 'Contributors' section of README.md in root directory of project

## What

Added Evan Hearne and Denis Pop as active contributors along with their GitHub profiles under the 'Contributors' section on README.md in root directory of project.

## Why

Because Evan Hearne and Denis Pop are actively contributing to this project. They have made many pull requests between them that have been successfully merged.

## How

Changes were made using Sublime Text 3 under the evanhearne1-adding-new-contributors-to-readme branch on the fork evanhearne.

## Verification Steps

Look at changes made to this branch and verify that the names 'Evan Hearne' and 'Denis Pop' along with their profiles are present under the 'Contributors' section of README.md and ensure that the links work.


# Checklist:

- [x] This pr is linked to the related trello card
- [x] My code follows the style guidelines of this project
- [ ] I have requested a code review from (at least) two team members
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] This change has been verified by another team member
