### PR TITLE
Revamped Contact Page + Moved Where to Find Us to About Tab from Contact Page

### DIFF
--- a/assets/html-navbar-footer/navigation.html
+++ b/assets/html-navbar-footer/navigation.html
@@ -9,6 +9,7 @@
         <div class="ui inverted blue simple dropdown item">
             About <i class="dropdown icon"></i>
             <div class="menu">
+                <a class="item" href="../../../../../pages/about/where.html">Where to Find Us</a>
                 <a class="item" href="../../../../../pages/about/history.html">History</a> <a class="item" href="../../../../../pages/about/mission.html">Mission Statement</a> <a class="item" href=
                 "../../../../../pages/about/staff.html">Staff</a> <a class="item" href="../../../../../pages/about/policies.html">School Policies</a> <a class="item" href=
                 "../../../../../pages/about/testimonials.html">Testimonials</a> <a class="item" href="../../../../../pages/about/inspection.html">Inspection Reports</a>

--- a/pages/about/Calendar.html
+++ b/pages/about/Calendar.html
@@ -5,6 +5,7 @@
     <link href="./assets/favicon.ico" rel="icon" type="../../image/x-icon">
     <link href="../../semantic/out/semantic.min.css" rel="stylesheet" type="text/css">
     <link href="../../assets/css/style.css" rel="stylesheet" type="text/css">
+    <link href="../../assets/favicon.ico" rel="icon" type="assets/image/x-icon">    
     <script src="https://code.jquery.com/jquery-3.1.1.min.js">
     </script>
     <script src="../../semantic/out/semantic.min.js">

--- a/pages/about/where.html
+++ b/pages/about/where.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mount Sion CBS Secondary School</title>
+    <link href="../../semantic/out/semantic.min.css" rel="stylesheet" type="text/css">
+    <link href="../../assets/css/style.css" rel="stylesheet" type="text/css">
+    <script src="https://code.jquery.com/jquery-3.1.1.min.js">
+    </script>
+    <script src="../../semantic/out/semantic.min.js">
+    </script>
+    <link href="../../assets/favicon.ico" rel="icon" type="assets/image/x-icon">
+      <script>
+          $(document).ready(function() {
+              $('#navbar').load('../../assets/html-navbar-footer/navigation.html');
+              $('#footer').load('../../assets/html-navbar-footer/footer.html');
+          });
+        </script></head>
+<body>
+    <div class="ui divbg container">
+        <img class="ui centered image" height="128px" src="../../assets/images/logo.jpg">
+        <div id="navbar"></div>
+        <div class="ui padded basic segment">
+            <h1 class="ui block header center blue aligned">Where to Find Us</h1>
+            <div class="ui blue segment">
+            <iframe allowfullscreen frameborder="0" height="450" src=
+                    "https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d9769.151915664062!2d-7.1166274!3d52.2563154!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0xf8355ef4efe9f1a4!2sMount+Sion+CBS+Secondary+School!5e0!3m2!1sen!2sie!4v1523822538739"
+                    style="border:0" width="100%"></iframe>
+    </div>
+</div>
+        </div>
+    </div>
+<div id="footer"></div>
+</body>
+</html>

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -4,6 +4,7 @@
     <title>Mount Sion CBS Secondary School</title>
     <link href="../semantic/out/semantic.min.css" rel="stylesheet" type="text/css">
     <link href="../assets/css/style.css" rel="stylesheet" type="text/css">
+        <link href="../../assets/favicon.ico" rel="icon" type="assets/image/x-icon">
     <script src="https://code.jquery.com/jquery-3.1.1.min.js">
     </script>
     <script src="../semantic/out/semantic.min.js">
@@ -26,20 +27,15 @@
                 <div class="ui padded basic segment">
                     <h1 class="ui block header center blue aligned">Contact Details</h1>
                     <div class="ui center aligned basic segment">
-                        <p>Email School:<a href="mailto:info@mountsioncbssecondary.ie" target="_top">info@mountsioncbssecondary.ie</a></p>
-                        <p>Web: mountsioncbssecondary.ie</p>
-                        <p>Telephone Number: 051 377378</p>
-                        <p>Fax Number: 051-376468</p>
-                        <p>School Roll No. 64930i</p>
-                        <p>Address:</p>
-                        <p>Mount Sion CBS Secondary School,</p>
+                        <p><a href="mailto:info@mountsioncbssecondary.ie"><i class="envelope link icon"></a></i>info@mountsioncbssecondary.ie</p> 
+                        <p><a target="_blank" href="http://www.mountsioncbssecondary.ie"><i class="globe icon"></i></a>mountsioncbssecondary.ie</p>
+                        <p><a href="tel:+35351377378"><i class="phone icon"></i></a>051 377378</p>
+                        <p><a href="tel:+35351376468"><i class="fax icon"></a></i>051 376468</p>
+                        <p><i class="building icon"></i>School Roll Number: 64930I</p>
+                        <p><a target="_blank" href="https://www.google.com/maps?ll=52.256315,-7.116627&z=14&t=m&hl=en-US&gl=IE&mapclient=embed&cid=17885305901261910436"><i class="address card icon"></a></i>Mount Sion CBS Secondary School,</p>
                         <p>Barrack Street,</p>
                         <p>Waterford City.</p>
-                        <p>School Location on Google maps</p>
                     </div>
-                    <h1 class="ui block header center blue aligned">Where to Find Us</h1><iframe allowfullscreen frameborder="0" height="450" src=
-                    "https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d9769.151915664062!2d-7.1166274!3d52.2563154!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x0%3A0xf8355ef4efe9f1a4!2sMount+Sion+CBS+Secondary+School!5e0!3m2!1sen!2sie!4v1523822538739"
-                    style="border:0" width="100%"></iframe>
                 </div>
             </div><br>
         </div>

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -28,11 +28,11 @@
                     <h1 class="ui block header center blue aligned">Contact Details</h1>
                     <div class="ui center aligned basic segment">
                         <p><a href="mailto:info@mountsioncbssecondary.ie"><i class="envelope link icon"></a></i>info@mountsioncbssecondary.ie</p> 
-                        <p><a target="_blank" href="http://www.mountsioncbssecondary.ie"><i class="globe icon"></i></a>mountsioncbssecondary.ie</p>
                         <p><a href="tel:+35351377378"><i class="phone icon"></i></a>051 377378</p>
                         <p><a href="tel:+35351376468"><i class="fax icon"></a></i>051 376468</p>
                         <p><i class="building icon"></i>School Roll Number: 64930I</p>
-                        <p><a target="_blank" href="https://www.google.com/maps?ll=52.256315,-7.116627&z=14&t=m&hl=en-US&gl=IE&mapclient=embed&cid=17885305901261910436"><i class="address card icon"></a></i>Mount Sion CBS Secondary School,</p>
+                        <p><a target="_blank" href="https://www.google.com/maps?ll=52.256315,-7.116627&z=14&t=m&hl=en-US&gl=IE&mapclient=embed&cid=17885305901261910436"><i class="address card icon"></a></i>School Address:</p>
+                        <p>Mount Sion CBS Secondary School,</p>
                         <p>Barrack Street,</p>
                         <p>Waterford City.</p>
                     </div>

--- a/pages/contact.html
+++ b/pages/contact.html
@@ -29,7 +29,7 @@
                     <div class="ui center aligned basic segment">
                         <p><a href="mailto:info@mountsioncbssecondary.ie"><i class="envelope link icon"></a></i>info@mountsioncbssecondary.ie</p> 
                         <p><a href="tel:+35351377378"><i class="phone icon"></i></a>051 377378</p>
-                        <p><a href="tel:+35351376468"><i class="fax icon"></a></i>051 376468</p>
+                        <p><i class="fax icon"></i>051 376468</p>
                         <p><i class="building icon"></i>School Roll Number: 64930I</p>
                         <p><a target="_blank" href="https://www.google.com/maps?ll=52.256315,-7.116627&z=14&t=m&hl=en-US&gl=IE&mapclient=embed&cid=17885305901261910436"><i class="address card icon"></a></i>School Address:</p>
                         <p>Mount Sion CBS Secondary School,</p>


### PR DESCRIPTION
# Description

Titles for contact info has been replaced with hyperlinked icons, a Where to Find Us page has been made and added to the About Tab.

## What

-Hyperlinked icons replaced contact info titles
-Where to Find Us page has been made, added to About tab
-Navigation bar has been updated to reflect changes
-Tab image has been added to contact.html and calendar.html

## Why

Contact page looked a bit messy, and a bit bland. The page now has hyperlinked icons to reflect modern users of internet - phones. Where to Find Us didn't really blend with the contact page, so it now has its own dedicated page in the About Tab.

## Verification Steps

http-server, go to About --> Where to Find Us and ensure that a page comes up with a map preview. http-server, go to Contact and ensure that a page comes up with hyperlinked icons, besides school code.

# Checklist:

- [x] This pr is linked to the related trello card
- [x] My code follows the style guidelines of this project
- [x] I have requested a code review from (at least) two team members
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] This change has been verified by another team member
